### PR TITLE
2021.02.21 - Regular update with multiple fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,12 +13,11 @@ We use github to host code, to track issues and feature requests, as well as acc
 ## All Code Contribution Changes Will Happen Through Pull Requests
 Pull requests are the best way to propose changes to the codebase.  We actively welcome your pull requests:
 
-1. Fork the repo and create your branch from `master`.
-2. If you've added code that should be tested, add tests.
-3. If you've changed APIs, update the documentation.
-4. Ensure the test suite passes.
-5. Make sure your code lints.
-6. Issue that pull request!
+1. Fork the repo and create your branch from `dev`.  Pull requests to `master` in most situations will be rejected.
+2. Make sure your code meets repository standards.
+3. DO NOT attempt to run the mkpkg script in the src directory.  Repository maintainer will reject all PRs that include binary data other than images.
+4. Issue that pull request!
+5. Repository maintainer performs reviews and requests changes as needed.  Be prepared for this before any merge is approved.
 
 ## Any contributions you make will be under the MIT Software License
 In short, when you submit code changes, your submissions are understood to be under the same [MIT License](http://choosealicense.com/licenses/mit/) that covers the project. Feel free to contact the maintainers if that's a concern.
@@ -44,7 +43,12 @@ People *love* thorough bug reports. I'm not even kidding.
 ## Use a Consistent Coding Style
 Use existing repository code (that you should have already reviewed) as a guide
 
-* PHP should use tabs instead of spaces
+* PHP should use 4 spaces to denote a tab character
+* camelCase any variables/functions
+* Any new functions should have PHP Doc Blocks
+* Function braces open on next line
+* Avoid mixing languages in any one file if possible (put PHP, JS, and CSS in their own files in the proper directories)
+* By design, all PHP classes for vendors extend the main class.  Any function that applies to multiple vendors should be in the main class
 
 ## License
 By contributing, you agree that your contributions will be licensed under its MIT License.

--- a/README.md
+++ b/README.md
@@ -4,19 +4,21 @@ An UnRAID plugin for displaying GPU status
 ## Prerequisites
 
 #### NVIDIA:
-    - UnRAID 6.9.0 Beta 34 and below needs one of the following:
-      * UNRAID-Nvidia Plugin with Nvidia Kernel Installed
-      * Custom Kernel build with Nvidia drivers (e.g. end of the original post in this [thread](https://forums.unraid.net/topic/92865-support-ich777-nvidiadvbzfsiscsimft-kernel-helperbuilder-docker/))
-    - UnRAID 6.9.0 Beta 35 and newer needs one of the following:
-      * Nvidia Plugin by @ich777 from Community Apps
-      * Custom Kernel build with Nvidia drivers (e.g. end of the original post in this [thread](https://forums.unraid.net/topic/92865-support-ich777-nvidiadvbzfsiscsimft-kernel-helperbuilder-docker/))
+- UnRAID 6.9.0 Beta 34 and below needs one of the following:
+  * ~~UNRAID-Nvidia Plugin with Nvidia Kernel Installed~~
+  * Custom Kernel build with Nvidia drivers
+- UnRAID 6.9.0 Beta 35 and newer needs one of the following:
+  * Nvidia Plugin by @ich777 from Community Apps
+  * Custom Kernel build with Nvidia drivers
+
+For custom kernel builds, see the original post of the UnRAID-Kernel-Build-Helper [thread](https://forums.unraid.net/topic/92865-support-ich777-nvidiadvbzfsiscsimft-kernel-helperbuilder-docker/).
 
 #### INTEL:
-    - UnRAID (All Versions)
-      * Intel GPU TOP plugin by @ich777 from Community Apps
+- UnRAID (All Versions)
+  * Intel GPU TOP plugin by @ich777 from Community Apps
 
 Note: From an UnRAID console if `nvidia-smi` (NVIDIA) or `intel_gpu_top` (Intel) cannot be found or run for any reason,
-the plugin will fail for that vendor.  If neither command exists, the plugin install will fail.
+the plugin will fail for that vendor. If neither command exists, the plugin install will fail.
 
 ## Manual Installation
     - Make sure all pre-requisites are installed and configured as needed

--- a/gpustat.xml
+++ b/gpustat.xml
@@ -9,15 +9,15 @@
     <Name>GPU Statistics</Name>
     <Description>
         This plugin parses GPU statistic data from vendor specific utilities and displays a subset of them on the dashboard.
-
-        Requires UnRAID-Nvidia plugin and kernel install or Custom Kernel with Nvidia drivers on 6.9.0 Beta34 and below for NVIDIA support,
-        for 6.9.0 Beta 35 and up, you either need a custom kernel or the Nvidia Driver plugin from @ich777 on Community Apps
-
-        Requires Intel GPU TOP plugin from @ich777 on Community Apps for Intel support
+        &#xD;
+        Requires UnRAID-Nvidia plugin (deprecated) and kernel install or Custom Kernel with Nvidia drivers on 6.9.0 Beta34 and below for NVIDIA support,
+        for 6.9.0 Beta 35 and up, you either need a custom kernel or the Nvidia Driver plugin from @ich777 on Community Apps.
+        &#xD;
+        Requires Intel GPU TOP plugin from @ich777 on Community Apps for Intel support.
     </Description>
     <MinVer>6.7.1</MinVer>
     <Project>https://github.com/b3rs3rk/gpustat-unraid</Project>
     <Support>https://forums.unraid.net/topic/89453-plugin-gpu-statistics/</Support>
     <Icon>https://raw.githubusercontent.com/b3rs3rk/gpustat-unraid/master/src/gpustat/usr/local/emhttp/plugins/gpustat/images/gpustat.png</Icon>
-    <License>MIT Copyright 2021 b3rs3rk</License>
+    <License>MIT License - Copyright 2020-2021 b3rs3rk</License>
 </Containers>

--- a/src/gpustat/usr/local/emhttp/plugins/gpustat/css/style.css
+++ b/src/gpustat/usr/local/emhttp/plugins/gpustat/css/style.css
@@ -38,5 +38,5 @@ span.gpu-img-span {
 .gpu-image {
     padding-left: 8px;
     height: auto;
-    width: 6%;
+    width: 10%;
 }

--- a/src/gpustat/usr/local/emhttp/plugins/gpustat/css/style.css
+++ b/src/gpustat/usr/local/emhttp/plugins/gpustat/css/style.css
@@ -37,6 +37,6 @@ span.gpu-img-span {
 
 .gpu-image {
     padding-left: 8px;
-    height: 6%;
+    height: auto;
     width: 6%;
 }

--- a/src/gpustat/usr/local/emhttp/plugins/gpustat/gpustatus.page
+++ b/src/gpustat/usr/local/emhttp/plugins/gpustat/gpustatus.page
@@ -152,9 +152,9 @@ Icon="gpustat.png"
             <td>Session Total - Apps</td>
             <td colspan="2">
                 <span class='gpu-sessions load'></span>
-                <span class='gpu-img-span gpu-img-span-plex'><img class='gpu-image' src="/plugins/gpustat/images/plex.png"></span>
-                <span class='gpu-img-span gpu-img-span-jelly'><img class='gpu-image' src="/plugins/gpustat/images/jellyfin.png"></span>
-                <span class='gpu-img-span gpu-img-span-emby'><img class='gpu-image' src="/plugins/gpustat/images/emby.png"></span>
+                <span id="gpu-img-span-plex" class='gpu-img-span gpu-img-span-plex'><img id='gpu-plex' class='gpu-image' src="/plugins/gpustat/images/plex.png"></span>
+                <span id="gpu-img-span-jelly" class='gpu-img-span gpu-img-span-jelly'><img id='gpu-jelly' class='gpu-image' src="/plugins/gpustat/images/jellyfin.png"></span>
+                <span id="gpu-img-span-emby" class='gpu-img-span gpu-img-span-emby'><img id='gpu-emby' class='gpu-image' src="/plugins/gpustat/images/emby.png"></span>
             </td>
             <td></td>
         </tr>

--- a/src/gpustat/usr/local/emhttp/plugins/gpustat/gpustatus.page
+++ b/src/gpustat/usr/local/emhttp/plugins/gpustat/gpustatus.page
@@ -57,7 +57,10 @@ Icon="gpustat.png"
                     <span id='load'>Load: <span class='gpu-util'></span></span>
 <?php if ($gpu_nv) : ?>
 <?php if($gpustat_cfg['DISPTEMP']) : ?>
-                    <span id='gpu-temp'>Temperature: <span class='gpu-temp'></span></span>
+                    <span>Temperature: <span class='gpu-temp'></span></span>
+<?php endif; ?>
+<?php if ($gpustat_cfg['DISPSESSIONS']) : ?>
+                    &emsp;&ensp;<span>Processes: <span class='gpu-sessions'></span></span>
 <?php endif; ?>
 <?php endif; ?>
                 </div>
@@ -130,28 +133,24 @@ Icon="gpustat.png"
             <td></td>
         </tr>
 <?php endif; ?>
-<?php if($gpustat_cfg['DISPTHROTTLE']) : ?>
+<?php if($gpustat_cfg['DISPTHROTTLE'] || $gpustat_cfg['DISPPWRSTATE']): ?>
         <tr class="dash_gpustat_toggle gpu-enviro">
             <td></td>
-            <td>Throttled</td>
-            <td colspan="2"><span class='gpu-throttled load'></span>&nbsp;<span class='gpu-thrtlrsn load'></span></td>
-            <td></td>
-        </tr>
-<?php endif; ?>
+            <td>Power State - Throttling</td>
 <?php if($gpustat_cfg['DISPPWRSTATE']) : ?>
-        <tr class="dash_gpustat_toggle gpu-enviro">
-            <td></td>
-            <td>Power State</td>
-            <td colspan="2"><span class='gpu-perfstate load'></span></td>
+            <td><span class='gpu-perfstate load'></span></td>
+<?php endif; ?>
+<?php if($gpustat_cfg['DISPTHROTTLE']): ?>
+            <td><span class='gpu-throttled load'></span>&nbsp;<span class='gpu-thrtlrsn load'></span></td>
+<?php endif; ?>
             <td></td>
         </tr>
 <?php endif; ?>
 <?php if($gpustat_cfg['DISPSESSIONS']) : ?>
         <tr class="dash_gpustat_toggle gpu-enviro">
             <td></td>
-            <td>Session Total - Apps</td>
+            <td>Active Apps</td>
             <td colspan="2">
-                <span class='gpu-sessions load'></span>
                 <span id="gpu-img-span-plex" class='gpu-img-span gpu-img-span-plex'><img id='gpu-plex' class='gpu-image' src="/plugins/gpustat/images/plex.png"></span>
                 <span id="gpu-img-span-jelly" class='gpu-img-span gpu-img-span-jelly'><img id='gpu-jelly' class='gpu-image' src="/plugins/gpustat/images/jellyfin.png"></span>
                 <span id="gpu-img-span-emby" class='gpu-img-span gpu-img-span-emby'><img id='gpu-emby' class='gpu-image' src="/plugins/gpustat/images/emby.png"></span>

--- a/src/gpustat/usr/local/emhttp/plugins/gpustat/gpustatus.php
+++ b/src/gpustat/usr/local/emhttp/plugins/gpustat/gpustatus.php
@@ -40,10 +40,10 @@ if (!isset($gpustat_cfg)) {
     $gpustat_cfg = Main::getSettings();
 }
 
-// $gpu_inventory should be set if called from settings page code
+// $gpustat_inventory should be set if called from settings page code
 if (isset($gpustat_inventory) && $gpustat_inventory) {
     $gpustat_cfg['inventory'] = true;
-    // Settings page looks for $gpu_data specifically -- inventory all supported GPU types
+    // Settings page looks for $gpustat_data specifically -- inventory all supported GPU types
     $gpustat_data = (new Nvidia($gpustat_cfg))->getInventory();
     $gpustat_data += (new Intel($gpustat_cfg))->getInventory();
 

--- a/src/gpustat/usr/local/emhttp/plugins/gpustat/lib/Nvidia.php
+++ b/src/gpustat/usr/local/emhttp/plugins/gpustat/lib/Nvidia.php
@@ -160,36 +160,36 @@ class Nvidia extends Main
                 }
                 if ($this->settings['DISPENCDEC']) {
                     if (isset($data->utilization->encoder_util)) {
-                        $this->pageData['encutil'] = (string)$this->stripSpaces($data->utilization->encoder_util);
+                        $this->pageData['encutil'] = (string) $this->stripSpaces($data->utilization->encoder_util);
                     }
                     if (isset($data->utilization->decoder_util)) {
-                        $this->pageData['decutil'] = (string)$this->stripSpaces($data->utilization->decoder_util);
+                        $this->pageData['decutil'] = (string) $this->stripSpaces($data->utilization->decoder_util);
                     }
                 }
             }
             if ($this->settings['DISPTEMP']) {
                 if (isset($data->temperature)) {
                     if (isset($data->temperature->gpu_temp)) {
-                        $this->pageData['temp'] = (string)str_replace('C', '°C', $data->temperature->gpu_temp);
+                        $this->pageData['temp'] = (string) str_replace('C', '°C', $data->temperature->gpu_temp);
                     }
                     if (isset($data->temperature->gpu_temp_max_threshold)) {
-                        $this->pageData['tempmax'] = (string)str_replace('C', '°C', $data->temperature->gpu_temp_max_threshold);
+                        $this->pageData['tempmax'] = (string) str_replace('C', '°C', $data->temperature->gpu_temp_max_threshold);
                     }
                     if ($this->settings['TEMPFORMAT'] == 'F') {
                         foreach (['temp', 'tempmax'] as $key) {
-                            $this->pageData[$key] = $this->convertCelsius((int)$this->stripText('C', $this->pageData[$key])) . 'F';
+                            $this->pageData[$key] = $this->convertCelsius((int) $this->stripText('C', $this->pageData[$key])) . 'F';
                         }
                     }
                 }
             }
             if ($this->settings['DISPFAN']) {
                 if (isset($data->fan_speed)) {
-                    $this->pageData['fan'] = (string)$this->stripSpaces($data->fan_speed);
+                    $this->pageData['fan'] = (string) $this->stripSpaces($data->fan_speed);
                 }
             }
             if ($this->settings['DISPPWRSTATE']) {
                 if (isset($data->performance_state)) {
-                    $this->pageData['perfstate'] = (string)$this->stripSpaces($data->performance_state);
+                    $this->pageData['perfstate'] = (string) $this->stripSpaces($data->performance_state);
                 }
             }
             if ($this->settings['DISPTHROTTLE']) {
@@ -207,23 +207,23 @@ class Nvidia extends Main
             if ($this->settings['DISPPWRDRAW']) {
                 if (isset($data->power_readings)) {
                     if (isset($data->power_readings->power_draw)) {
-                        $this->pageData['power'] = (float)$this->stripText(' W', $data->power_readings->power_draw);
-                        $this->pageData['power'] = (string)$this->roundFloat($this->pageData['power']) . 'W';
+                        $this->pageData['power'] = (float) $this->stripText(' W', $data->power_readings->power_draw);
+                        $this->pageData['power'] = (string) $this->roundFloat($this->pageData['power']) . 'W';
                     }
                     if (isset($data->power_readings->power_limit)) {
-                        $this->pageData['powermax'] = (string)$this->stripText('.00 W', $data->power_readings->power_limit);
+                        $this->pageData['powermax'] = (string) $this->stripText('.00 W', $data->power_readings->power_limit);
                     }
                 }
             }
             if ($this->settings['DISPCLOCKS']) {
                 if (isset($data->clocks, $data->max_clocks)) {
                     if (isset($data->clocks->graphics_clock, $data->max_clocks->graphics_clock)) {
-                        $this->pageData['clock'] = (string)$this->stripText(' MHz', $data->clocks->graphics_clock);
-                        $this->pageData['clockmax'] = (string)$this->stripText(' MHz', $data->max_clocks->graphics_clock);
+                        $this->pageData['clock'] = (string) $this->stripText(' MHz', $data->clocks->graphics_clock);
+                        $this->pageData['clockmax'] = (string) $this->stripText(' MHz', $data->max_clocks->graphics_clock);
                     }
                     if (isset($data->clocks->mem_clock, $data->max_clocks->mem_clock)) {
-                        $this->pageData['memclock'] = (string)$this->stripText(' MHz', $data->clocks->mem_clock);
-                        $this->pageData['memclockmax'] = (string)$this->stripText(' MHz', $data->max_clocks->mem_clock);
+                        $this->pageData['memclock'] = (string) $this->stripText(' MHz', $data->clocks->mem_clock);
+                        $this->pageData['memclockmax'] = (string) $this->stripText(' MHz', $data->max_clocks->mem_clock);
                     }
                 }
             }
@@ -251,11 +251,11 @@ class Nvidia extends Main
                 if (isset($data->pci)) {
                     if (isset($data->pci->rx_util, $data->pci->tx_util)) {
                         // Not all cards support PCI RX/TX Measurements
-                        if ($data->pci->rx_util !== 'N/A') {
-                            $this->pageData['rxutil'] = (string)$this->roundFloat($this->stripText(' KB/s', $data->pci->rx_util) / 1000);
+                        if ((string) $data->pci->rx_util !== 'N/A') {
+                            $this->pageData['rxutil'] = (string) $this->roundFloat($this->stripText(' KB/s', $data->pci->rx_util) / 1000);
                         }
-                        if ($data->pci->tx_util !== 'N/A') {
-                            $this->pageData['txutil'] = (string)$this->roundFloat($this->stripText(' KB/s', $data->pci->tx_util) / 1000);
+                        if ((string) $data->pci->tx_util !== 'N/A') {
+                            $this->pageData['txutil'] = (string) $this->roundFloat($this->stripText(' KB/s', $data->pci->tx_util) / 1000);
                         }
                     }
                     if (
@@ -266,12 +266,12 @@ class Nvidia extends Main
                             $data->pci->pci_gpu_link_info->link_widths->max_link_width
                         )
                     ) {
-                        $this->pageData['pciegen'] = $generation = (int)$data->pci->pci_gpu_link_info->pcie_gen->current_link_gen;
-                        $this->pageData['pciewidth'] = $width = (int)$this->stripText('x', $data->pci->pci_gpu_link_info->link_widths->current_link_width);
+                        $this->pageData['pciegen'] = $generation = (int) $data->pci->pci_gpu_link_info->pcie_gen->current_link_gen;
+                        $this->pageData['pciewidth'] = $width = (int) $this->stripText('x', $data->pci->pci_gpu_link_info->link_widths->current_link_width);
                         // @ 16x Lanes: Gen 1 = 4000, 2 = 8000, 3 = 16000 MB/s -- Slider bars won't be that active with most workloads
                         $this->pageData['pciemax'] = pow(2, $generation - 1) * 250 * $width;
-                        $this->pageData['pciegenmax'] = (int)$data->pci->pci_gpu_link_info->pcie_gen->max_link_gen;
-                        $this->pageData['pciewidthmax'] = (int)$this->stripText('x', $data->pci->pci_gpu_link_info->link_widths->max_link_width);
+                        $this->pageData['pciegenmax'] = (int) $data->pci->pci_gpu_link_info->pcie_gen->max_link_gen;
+                        $this->pageData['pciewidthmax'] = (int) $this->stripText('x', $data->pci->pci_gpu_link_info->link_widths->max_link_width);
                     }
                 }
             }

--- a/src/gpustat/usr/local/emhttp/plugins/gpustat/lib/Nvidia.php
+++ b/src/gpustat/usr/local/emhttp/plugins/gpustat/lib/Nvidia.php
@@ -136,9 +136,9 @@ class Nvidia extends Main
                 'plexusing'     => false,
                 'plexmem'       => 0,
                 'plexcount'     => 0,
-                'jellyusing'     => false,
-                'jellymem'       => 0,
-                'jellycount'     => 0,
+                'jellyusing'    => false,
+                'jellymem'      => 0,
+                'jellycount'    => 0,
                 'embyusing'     => false,
                 'embymem'       => 0,
                 'embycount'     => 0,
@@ -229,15 +229,16 @@ class Nvidia extends Main
             }
             // For some reason, encoder_sessions->session_count is not reliable on my install, better to count processes
             if ($this->settings['DISPSESSIONS']) {
+                $this->pageData['appssupp'] = array_keys(self::SUPPORTED_APPS);
                 if (isset($data->processes->process_info)) {
-                    $this->pageData['sessions'] = (int)count($data->processes->process_info);
+                    $this->pageData['sessions'] = (int) count($data->processes->process_info);
                     if ($this->pageData['sessions'] > 0) {
                         foreach ($data->processes->children() as $process) {
                             foreach (self::SUPPORTED_APPS as $id => $app) {
                                 if (isset($process->process_name)) {
                                     if (strpos($process->process_name, $app) !== false) {
                                         $this->pageData[$id . "using"] = true;
-                                        $this->pageData[$id . "mem"] += (int)$this->stripText(' MiB', $process->used_memory);
+                                        $this->pageData[$id . "mem"] += (int) $this->stripText(' MiB', $process->used_memory);
                                         $this->pageData[$id . "count"]++;
                                     }
                                 }

--- a/src/gpustat/usr/local/emhttp/plugins/gpustat/scripts/gpustat.js
+++ b/src/gpustat/usr/local/emhttp/plugins/gpustat/scripts/gpustat.js
@@ -25,34 +25,35 @@
 const gpustat_status = () => {
     $.getJSON('/plugins/gpustat/gpustatus.php', (data) => {
         if(data) {
-            // Nvidia Slider Bars
-            $('.gpu-memclockbar').removeAttr('style').css('width', data["memclock"] / data["memclockmax"] * 100 + "%");
-            $('.gpu-gpuclockbar').removeAttr('style').css('width', data["clock"] / data["clockmax"] * 100 + "%");
-            $('.gpu-utilbar').removeAttr('style').css('width', data["util"]);
-            $('.gpu-memutilbar').removeAttr('style').css('width', data["memutil"]);
-            $('.gpu-encutilbar').removeAttr('style').css('width', data["encutil"]);
-            $('.gpu-decutilbar').removeAttr('style').css('width', data["decutil"]);
-            $('.gpu-fanbar').removeAttr('style').css('width', data["fan"]);
-            $('.gpu-powerbar').removeAttr('style').css('width', parseInt(data["power"].replace("W","") / data["powermax"] * 100) + "%");
-            $('.gpu-rxutilbar').removeAttr('style').css('width', parseInt(data["rxutil"] / data["pciemax"] * 100) + "%");
-            $('.gpu-txutilbar').removeAttr('style').css('width', parseInt(data["txutil"] / data["pciemax"] * 100) + "%");
+            if (data["vendor"] === 'NVIDIA') {
+                // Nvidia Slider Bars
+                $('.gpu-memclockbar').removeAttr('style').css('width', data["memclock"] / data["memclockmax"] * 100 + "%");
+                $('.gpu-gpuclockbar').removeAttr('style').css('width', data["clock"] / data["clockmax"] * 100 + "%");
+                $('.gpu-powerbar').removeAttr('style').css('width', parseInt(data["power"].replace("W","") / data["powermax"] * 100) + "%");
+                $('.gpu-rxutilbar').removeAttr('style').css('width', parseInt(data["rxutil"] / data["pciemax"] * 100) + "%");
+                $('.gpu-txutilbar').removeAttr('style').css('width', parseInt(data["txutil"] / data["pciemax"] * 100) + "%");
 
-            // Intel Slider Bars
-            $('.gpu-3drenderbar').removeAttr('style').css('width', data["3drender"]);
-            $('.gpu-blitterbar').removeAttr('style').css('width', data["blitter"]);
-            $('.gpu-videobar').removeAttr('style').css('width', data["video"]);
-            $('.gpu-videnhbar').removeAttr('style').css('width', data["videnh"]);
-            $('.gpu-powerutilbar').removeAttr('style').css('width', data["powerutil"]);
+                let nvidiabars = ["util", "memutil", "encutil", "decutil", "fan"];
+                nvidiabars.forEach(function (metric) {
+                    $('.gpu-'+metric+'bar').removeAttr('style').css('width', data[metric]);
+                });
 
-            if (data["appssupp"]) {
-                data["appssupp"].forEach(function (app) {
-                    if (data[app + "using"]) {
-                        $('.gpu-img-span-'+app).css('display', "inline");
-                        $('#gpu-'+app).attr('title', "Count: " + data[app+"count"] + " Memory: " + data[app+"mem"] + "MB");
-                    } else {
-                        $('.gpu-img-span-'+app).css('display', "none");
-                        $('#gpu-'+app).attr('title', "");
-                    }
+                if (data["appssupp"]) {
+                    data["appssupp"].forEach(function (app) {
+                        if (data[app + "using"]) {
+                            $('.gpu-img-span-'+app).css('display', "inline");
+                            $('#gpu-'+app).attr('title', "Count: " + data[app+"count"] + " Memory: " + data[app+"mem"] + "MB");
+                        } else {
+                            $('.gpu-img-span-'+app).css('display', "none");
+                            $('#gpu-'+app).attr('title', "");
+                        }
+                    });
+                }
+            } else if (data["vendor"] === 'Intel') {
+                // Intel Slider Bars
+                let intelbars = ["3drender", "blitter", "video", "videnh", "powerutil"];
+                intelbars.forEach(function (metric) {
+                    $('.gpu-'+metric+'bar').removeAttr('style').css('width', data[metric]);
                 });
             }
 

--- a/src/gpustat/usr/local/emhttp/plugins/gpustat/scripts/gpustat.js
+++ b/src/gpustat/usr/local/emhttp/plugins/gpustat/scripts/gpustat.js
@@ -44,21 +44,16 @@ const gpustat_status = () => {
             $('.gpu-videnhbar').removeAttr('style').css('width', data["videnh"]);
             $('.gpu-powerutilbar').removeAttr('style').css('width', data["powerutil"]);
 
-            // App Using Hardware
-            if (data["plexusing"]) {
-                $('.gpu-img-span-plex').css('display', "inline");
-            } else {
-                $('.gpu-img-span-plex').css('display', "none");
-            }
-            if (data["jellyusing"]) {
-                $('.gpu-img-span-jelly').css('display', "inline");
-            } else {
-                $('.gpu-img-span-jelly').css('display', "none");
-            }
-            if (data["embyusing"]) {
-                $('.gpu-img-span-emby').css('display', "inline");
-            } else {
-                $('.gpu-img-span-emby').css('display', "none");
+            if (data["appssupp"]) {
+                data["appssupp"].forEach(function (app) {
+                    if (data[app + "using"]) {
+                        $('.gpu-img-span-'+app).css('display', "inline");
+                        $('#gpu-'+app).attr('title', "Count: " + data[app+"count"] + " Memory: " + data[app+"mem"] + "MB");
+                    } else {
+                        $('.gpu-img-span-'+app).css('display', "none");
+                        $('#gpu-'+app).attr('title', "");
+                    }
+                });
             }
 
             $.each(data, function (key, data) {
@@ -76,7 +71,7 @@ const gpustat_dash = () => {
     toggleView('dash_gpustat_toggle', true);
 
     // reload sorting to get the stored data (cookie)
-    sortTable($('#db-box1'),$.cookie('db-box1'));
+    sortTable($('#db-box1'), $.cookie('db-box1'));
 }
 
 /*


### PR DESCRIPTION
- Fix for Chrome showing active application icons stretched vertically (NVIDIA) - #17 
- Fix for dashboard render issues relating to cards that don't support PCI utilization metrics (NVIDIA)
- Move total sessions display to dashboard header to avoid confusion
- Add hover (alt) to application icons so that individual app processes count and memory usage will be displayed